### PR TITLE
Add sanitized rich text resume summaries

### DIFF
--- a/Code/client/__tests__/components/resume/Form.test.tsx
+++ b/Code/client/__tests__/components/resume/Form.test.tsx
@@ -2,13 +2,17 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import userEvent from "@testing-library/user-event";
 import axios from "axios";
 import ResumeForm from "@/components/resume/Form";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import { useSafeUser } from "../../../hooks/useSafeUser";
 import { useLocalStorage } from "../../../hooks/useLocalStorage";
+import { sanitizeResumeRichTextFields } from "@/utils/richText";
 
 jest.mock("axios");
-jest.mock("react-hook-form");
+jest.mock("react-hook-form", () => ({
+  Controller: jest.fn(),
+  useForm: jest.fn(),
+}));
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
 }));
@@ -25,6 +29,19 @@ jest.mock("../../../components/Loader", () => ({
 jest.mock("../../../components/ScrollToTop", () => ({
   __esModule: true,
   default: () => <div data-testid="scroll-to-top" />,
+}));
+jest.mock("../../../components/common/RichTextEditor", () => ({
+  __esModule: true,
+  default: ({ content, onChange, error }: any) => (
+    <div>
+      <div data-testid="rich-text-editor" data-error={String(Boolean(error))}>
+        {content}
+      </div>
+      <button type="button" onClick={() => onChange("<p>Updated rich text</p>")}>
+        update-rich-text
+      </button>
+    </div>
+  ),
 }));
 jest.mock("../../../components/common/DraggableFormItem", () => ({
   __esModule: true,
@@ -114,9 +131,23 @@ describe("ResumeForm", () => {
       isLoading: false,
     });
     (useLocalStorage as jest.Mock).mockReturnValue([{}, mockSetLocalResume]);
+    (Controller as jest.Mock).mockImplementation(({ name, render }: any) =>
+      render({
+        field: {
+          name,
+          value: name
+            .split(".")
+            .reduce((acc: any, key: string) => (acc == null ? acc : acc[key]), currentValues),
+          onChange: jest.fn(),
+          onBlur: jest.fn(),
+          ref: jest.fn(),
+        },
+      })
+    );
     mockGetValues.mockImplementation(() => currentValues);
     (useForm as jest.Mock).mockReturnValue({
       register: mockRegister,
+      control: {},
       handleSubmit: (onValid: (data: any) => unknown) => async (event?: Event) => {
         event?.preventDefault?.();
         return onValid(currentValues);
@@ -175,6 +206,16 @@ describe("ResumeForm", () => {
       expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("/resume/user-123"));
       expect(mockReset).toHaveBeenCalledWith(fetchedResume);
     });
+  });
+
+  it("renders the rich text summary editor through Controller", () => {
+    render(<ResumeForm />);
+
+    expect(screen.getByTestId("rich-text-editor")).toBeInTheDocument();
+    expect(Controller).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "personal.summary" }),
+      undefined
+    );
   });
 
   it("adds a new skill item through the section handler", async () => {
@@ -236,15 +277,17 @@ describe("ResumeForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save and Preview" }));
 
     await waitFor(() => {
+      const sanitizedResume = sanitizeResumeRichTextFields(currentValues);
+
       expect(mockSetLocalResume).toHaveBeenCalledWith({
         user: "user-123",
-        resume: currentValues,
+        resume: sanitizedResume,
       });
       expect(axios.post).toHaveBeenCalledWith(
         expect.stringContaining("/resume"),
         {
           user: "user-123",
-          resume: currentValues,
+          resume: sanitizedResume,
         }
       );
       expect(mockPush).toHaveBeenCalledWith("/resume/preview");

--- a/Code/client/__tests__/components/resume/ResumeFieldComponents.test.tsx
+++ b/Code/client/__tests__/components/resume/ResumeFieldComponents.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen } from "@testing-library/react";
+import { Controller } from "react-hook-form";
+import type { UseFormRegister } from "react-hook-form";
 import CourseForm from "@/components/resume/CourseForm";
 import EducationForm from "@/components/resume/EducationForm";
 import EmploymentForm from "@/components/resume/EmploymentForm";
@@ -10,11 +12,38 @@ import ProficiencyFormFields from "@/components/resume/ProficiencyFormFields";
 import ReferenceForm from "@/components/resume/ReferenceForm";
 import SkillForm from "@/components/resume/SkillForm";
 
+jest.mock("react-hook-form", () => ({
+  Controller: jest.fn(),
+}));
+
+jest.mock("../../../components/common/RichTextEditor", () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => <div data-testid="rich-text-editor">{content}</div>,
+}));
+
 describe("resume field components", () => {
-  const mockRegister = jest.fn(() => ({}));
+  const mockRegisterImpl = jest.fn((name: string) => ({
+    name,
+    onChange: jest.fn(),
+    onBlur: jest.fn(),
+    ref: jest.fn(),
+  }));
+  const mockRegister = mockRegisterImpl as unknown as UseFormRegister<any>;
+  const mockControl = {} as any;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (Controller as jest.Mock).mockImplementation(({ name, render }: any) =>
+      render({
+        field: {
+          name,
+          value: "<p>Formatted summary</p>",
+          onChange: jest.fn(),
+          onBlur: jest.fn(),
+          ref: jest.fn(),
+        },
+      })
+    );
   });
 
   it("renders education fields with fallback heading and correct register paths", () => {
@@ -35,12 +64,12 @@ describe("resume field components", () => {
     expect(screen.getByText("Education # 2")).toBeInTheDocument();
     expect(screen.getByText("School/University*")).toBeInTheDocument();
     expect(screen.getByText("Subject/Degree*")).toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("educations.1.institution");
-    expect(mockRegister).toHaveBeenCalledWith("educations.1.subject");
-    expect(mockRegister).toHaveBeenCalledWith("educations.1.startDate");
-    expect(mockRegister).toHaveBeenCalledWith("educations.1.endDate");
-    expect(mockRegister).toHaveBeenCalledWith("educations.1.score", {});
-    expect(mockRegister).toHaveBeenCalledWith("educations.1.location", {});
+    expect(mockRegisterImpl).toHaveBeenCalledWith("educations.1.institution");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("educations.1.subject");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("educations.1.startDate");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("educations.1.endDate");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("educations.1.score", {});
+    expect(mockRegisterImpl).toHaveBeenCalledWith("educations.1.location", {});
   });
 
   it("renders course fields with stable labels and register paths", () => {
@@ -58,16 +87,17 @@ describe("resume field components", () => {
 
     expect(screen.getByLabelText("Course Name")).toHaveValue("System Design");
     expect(screen.getByLabelText("Institution Name")).toHaveValue("Udemy");
-    expect(mockRegister).toHaveBeenCalledWith("courses.0.name");
-    expect(mockRegister).toHaveBeenCalledWith("courses.0.institution");
-    expect(mockRegister).toHaveBeenCalledWith("courses.0.startDate");
-    expect(mockRegister).toHaveBeenCalledWith("courses.0.endDate");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("courses.0.name");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("courses.0.institution");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("courses.0.startDate");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("courses.0.endDate");
   });
 
   it("renders employment fields through the shared experience helper", () => {
     render(
       <EmploymentForm
         register={mockRegister}
+        control={mockControl}
         title="Lead Engineer"
         company="EPAM"
         startDate="2023-01"
@@ -82,23 +112,24 @@ describe("resume field components", () => {
 
     expect(screen.getByText("Lead Engineer at EPAM")).toBeInTheDocument();
     expect(screen.getByText("Is Present Company?")).toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("employments.0.title");
-    expect(mockRegister).toHaveBeenCalledWith("employments.0.company");
-    expect(mockRegister).toHaveBeenCalledWith("employments.0.startDate");
-    expect(mockRegister).toHaveBeenCalledWith("employments.0.endDate");
-    expect(mockRegister).toHaveBeenCalledWith("employments.0.location", {});
-    expect(mockRegister).toHaveBeenCalledWith("employments.0.isCurrent");
-    expect(mockRegister).toHaveBeenCalledWith("employments.0.summary", {
-      required: true,
-      maxLength: 4000,
-      minLength: 50,
-    });
+    expect(mockRegisterImpl).toHaveBeenCalledWith("employments.0.title");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("employments.0.company");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("employments.0.startDate");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("employments.0.endDate");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("employments.0.location", {});
+    expect(mockRegisterImpl).toHaveBeenCalledWith("employments.0.isCurrent");
+    expect(screen.getByTestId("rich-text-editor")).toBeInTheDocument();
+    expect(Controller).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "employments.0.summary" }),
+      undefined
+    );
   });
 
   it("renders internship fields without the current-company checkbox", () => {
     render(
       <InternshipForm
         register={mockRegister}
+        control={mockControl}
         title="Trainee"
         company="Acme"
         startDate="2023-01"
@@ -113,13 +144,12 @@ describe("resume field components", () => {
 
     expect(screen.getByText("Trainee at Acme")).toBeInTheDocument();
     expect(screen.queryByText("Is Present Company?")).not.toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("internships.2.title");
-    expect(mockRegister).toHaveBeenCalledWith("internships.2.company");
-    expect(mockRegister).toHaveBeenCalledWith("internships.2.summary", {
-      required: true,
-      maxLength: 4000,
-      minLength: 50,
-    });
+    expect(mockRegisterImpl).toHaveBeenCalledWith("internships.2.title");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("internships.2.company");
+    expect(Controller).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "internships.2.summary" }),
+      undefined
+    );
   });
 
   it("renders skill fields against the skills base path", () => {
@@ -135,8 +165,8 @@ describe("resume field components", () => {
 
     expect(screen.getByText("Skill Name*")).toBeInTheDocument();
     expect(screen.getByText("Level*")).toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("skills.1.name");
-    expect(mockRegister).toHaveBeenCalledWith("skills.1.level");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("skills.1.name");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("skills.1.level");
   });
 
   it("renders language fields against the languages base path", () => {
@@ -151,8 +181,8 @@ describe("resume field components", () => {
     );
 
     expect(screen.getByText("Language Name*")).toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("languages.0.name");
-    expect(mockRegister).toHaveBeenCalledWith("languages.0.level");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("languages.0.name");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("languages.0.level");
   });
 
   it("renders website link fields", () => {
@@ -168,8 +198,8 @@ describe("resume field components", () => {
 
     expect(screen.getByText("Website Name")).toBeInTheDocument();
     expect(screen.getByText("Link/URL (starts with http* or www.*)")).toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("links.0.name", {});
-    expect(mockRegister).toHaveBeenCalledWith("links.0.url", {});
+    expect(mockRegisterImpl).toHaveBeenCalledWith("links.0.name", {});
+    expect(mockRegisterImpl).toHaveBeenCalledWith("links.0.url", {});
   });
 
   it("renders reference fields", () => {
@@ -189,16 +219,17 @@ describe("resume field components", () => {
     expect(screen.getByText("Company Name")).toBeInTheDocument();
     expect(screen.getByText("Email")).toBeInTheDocument();
     expect(screen.getByText("Phone")).toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("references.0.name");
-    expect(mockRegister).toHaveBeenCalledWith("references.0.company");
-    expect(mockRegister).toHaveBeenCalledWith("references.0.email");
-    expect(mockRegister).toHaveBeenCalledWith("references.0.phone");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("references.0.name");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("references.0.company");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("references.0.email");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("references.0.phone");
   });
 
   it("renders the shared experience fields with the optional checkbox", () => {
     render(
       <ExperienceFormFields
         register={mockRegister}
+        control={mockControl}
         index={3}
         basePath="employments"
         title="Architect"
@@ -218,7 +249,11 @@ describe("resume field components", () => {
     expect(screen.getByText("Job Title*")).toBeInTheDocument();
     expect(screen.getByText("Company Name*")).toBeInTheDocument();
     expect(screen.getByText("Is Present Company?")).toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("employments.3.isCurrent");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("employments.3.isCurrent");
+    expect(Controller).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "employments.3.summary" }),
+      undefined
+    );
   });
 
   it("renders the shared proficiency fields with the expected select options", () => {
@@ -237,7 +272,7 @@ describe("resume field components", () => {
     expect(screen.getByText("Skill Name*")).toBeInTheDocument();
     expect(document.querySelector('option[label="Novice"]')).toBeInTheDocument();
     expect(document.querySelector('option[label="Expert"]')).toBeInTheDocument();
-    expect(mockRegister).toHaveBeenCalledWith("skills.2.name");
-    expect(mockRegister).toHaveBeenCalledWith("skills.2.level");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("skills.2.name");
+    expect(mockRegisterImpl).toHaveBeenCalledWith("skills.2.level");
   });
 });

--- a/Code/client/components/common/RichTextContent.tsx
+++ b/Code/client/components/common/RichTextContent.tsx
@@ -1,0 +1,16 @@
+import { sanitizeRichTextHtml } from "@/utils/richText";
+
+export default function RichTextContent({
+  content,
+  className = "",
+}: {
+  content: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{ __html: sanitizeRichTextHtml(content) }}
+    />
+  );
+}

--- a/Code/client/components/common/RichTextEditor.tsx
+++ b/Code/client/components/common/RichTextEditor.tsx
@@ -1,100 +1,150 @@
 "use client";
 
-import { useEditor, EditorContent } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
-import { FaBold, FaItalic, FaUnderline, FaListUl, FaListOl } from 'react-icons/fa';
-import { useEffect } from 'react';
+import { Editor, EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Underline from "@tiptap/extension-underline";
+import { FaBold, FaItalic, FaListOl, FaListUl, FaUnderline } from "react-icons/fa";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { normalizeRichTextContent, sanitizeRichTextHtml } from "@/utils/richText";
 
 interface RichTextEditorProps {
   content: string;
   onChange: (content: string) => void;
   error?: boolean;
+  minHeightClassName?: string;
 }
 
-const MenuBar = ({ editor }: { editor: any }) => {
+function ToolbarButton({
+  active,
+  disabled,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  disabled: boolean;
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Button
+      type="button"
+      variant={active ? "secondary" : "ghost"}
+      size="icon-sm"
+      aria-label={label}
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={onClick}
+      className="text-foreground"
+    >
+      {children}
+    </Button>
+  );
+}
+
+const MenuBar = ({ editor }: { editor: Editor | null }) => {
   if (!editor) {
     return null;
   }
 
   return (
-    <div className="flex gap-1 p-2 border-b border-base-300">
-      <button
-        onClick={() => editor.chain().focus().toggleBold().run()}
+    <div className="flex flex-wrap items-center gap-1 border-b border-border/70 bg-muted/30 p-2">
+      <ToolbarButton
+        label="Bold"
+        active={editor.isActive("bold")}
         disabled={!editor.can().chain().focus().toggleBold().run()}
-        className={`p-2 hover:bg-base-200 rounded ${editor.isActive('bold') ? 'bg-base-300' : ''}`}
-        aria-label="Bold"
-        type="button"
+        onClick={() => editor.chain().focus().toggleBold().run()}
       >
         <FaBold className="w-4 h-4" />
-      </button>
-      <button
-        onClick={() => editor.chain().focus().toggleItalic().run()}
+      </ToolbarButton>
+      <ToolbarButton
+        label="Italic"
+        active={editor.isActive("italic")}
         disabled={!editor.can().chain().focus().toggleItalic().run()}
-        className={`p-2 hover:bg-base-200 rounded ${editor.isActive('italic') ? 'bg-base-300' : ''}`}
-        aria-label="Italic"
-        type="button"
+        onClick={() => editor.chain().focus().toggleItalic().run()}
       >
         <FaItalic className="w-4 h-4" />
-      </button>
-      <button
-        onClick={() => editor.chain().focus().toggleUnderline().run()}
+      </ToolbarButton>
+      <ToolbarButton
+        label="Underline"
+        active={editor.isActive("underline")}
         disabled={!editor.can().chain().focus().toggleUnderline().run()}
-        className={`p-2 hover:bg-base-200 rounded ${editor.isActive('underline') ? 'bg-base-300' : ''}`}
-        aria-label="Underline"
-        type="button"
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
       >
         <FaUnderline className="w-4 h-4" />
-      </button>
-      <div className="w-px bg-base-300 mx-1" />
-      <button
-        onClick={() => editor.chain().focus().toggleBulletList().run()}
+      </ToolbarButton>
+      <div className="mx-1 h-6 w-px bg-border/80" />
+      <ToolbarButton
+        label="Bullet List"
+        active={editor.isActive("bulletList")}
         disabled={!editor.can().chain().focus().toggleBulletList().run()}
-        className={`p-2 hover:bg-base-200 rounded ${editor.isActive('bulletList') ? 'bg-base-300' : ''}`}
-        aria-label="Bullet List"
-        type="button"
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
       >
         <FaListUl className="w-4 h-4" />
-      </button>
-      <button
-        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+      </ToolbarButton>
+      <ToolbarButton
+        label="Ordered List"
+        active={editor.isActive("orderedList")}
         disabled={!editor.can().chain().focus().toggleOrderedList().run()}
-        className={`p-2 hover:bg-base-200 rounded ${editor.isActive('orderedList') ? 'bg-base-300' : ''}`}
-        aria-label="Ordered List"
-        type="button"
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
       >
         <FaListOl className="w-4 h-4" />
-      </button>
+      </ToolbarButton>
     </div>
   );
 };
 
-export default function RichTextEditor({ content, onChange, error }: RichTextEditorProps) {
+export default function RichTextEditor({
+  content,
+  onChange,
+  error = false,
+  minHeightClassName = "min-h-[10rem]",
+}: RichTextEditorProps) {
   const editor = useEditor({
     extensions: [
-      StarterKit,
+      StarterKit.configure({
+        heading: false,
+        blockquote: false,
+        code: false,
+        codeBlock: false,
+        horizontalRule: false,
+      }),
       Underline,
     ],
-    content: content,
+    content: normalizeRichTextContent(content),
+    immediatelyRender: false,
     editorProps: {
       attributes: {
-        class: 'prose max-w-none min-h-[200px] p-4 focus:outline-none',
+        class: cn(
+          "prose prose-sm max-w-none px-4 py-3 text-foreground focus:outline-none dark:prose-invert",
+          minHeightClassName,
+          "[&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_ul]:list-disc [&_ul]:pl-5"
+        ),
       },
     },
     onUpdate: ({ editor }) => {
-      onChange(editor.getHTML());
+      onChange(sanitizeRichTextHtml(editor.getHTML()));
     },
   });
 
-  // Update editor content when prop changes
   useEffect(() => {
-    if (editor && content !== editor.getHTML()) {
-      editor.commands.setContent(content);
+    const normalizedContent = normalizeRichTextContent(content);
+
+    if (editor && normalizedContent !== editor.getHTML()) {
+      editor.commands.setContent(normalizedContent, false);
     }
   }, [content, editor]);
 
   return (
-    <div className={`border rounded-lg overflow-hidden ${error ? 'border-error' : 'border-base-300'}`}>
+    <div
+      className={cn(
+        "overflow-hidden rounded-lg border bg-background",
+        error ? "border-destructive ring-3 ring-destructive/20" : "border-input"
+      )}
+    >
       <MenuBar editor={editor} />
       <EditorContent editor={editor} />
     </div>

--- a/Code/client/components/preview/DefaultTemplate.tsx
+++ b/Code/client/components/preview/DefaultTemplate.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import RichTextContent from '@/components/common/RichTextContent';
 
 interface Props {
   data: any;
@@ -102,7 +103,10 @@ const DefaultTemplate = ({ data: r, color, colorClasses, bgColorClasses }: Props
             {/* Main Content */}
             <section className="py-4">
               <SectionTitle color={colorClasses[color]}>Profile</SectionTitle>
-              <p className="mt-4 text-gray-500">{r?.personal?.summary}</p>
+              <RichTextContent
+                content={r?.personal?.summary}
+                className="mt-4 text-gray-500 prose prose-sm max-w-none [&_ol]:pl-5 [&_p]:my-2 [&_ul]:pl-5"
+              />
             </section>
 
             {r?.internships?.[0]?.title && (
@@ -112,7 +116,10 @@ const DefaultTemplate = ({ data: r, color, colorClasses, bgColorClasses }: Props
                   <article className="" key={i}>
                     <CompanyHeader title={v.title} company={v.company} location={v.location} />
                     <DateRange startDate={v.startDate} endDate={v.endDate} />
-                    <p className="mt-4 text-gray-500">{v?.summary}</p>
+                    <RichTextContent
+                      content={v?.summary}
+                      className="mt-4 text-gray-500 prose prose-sm max-w-none [&_ol]:pl-5 [&_p]:my-2 [&_ul]:pl-5"
+                    />
                   </article>
                 ))}
               </section>
@@ -125,7 +132,10 @@ const DefaultTemplate = ({ data: r, color, colorClasses, bgColorClasses }: Props
                   <article className="" key={i}>
                     <CompanyHeader title={v.title} company={v.company} location={v.location} />
                     <DateRange startDate={v.startDate} endDate={v.endDate} isCurrent={v.isCurrent} />
-                    <p className="mt-4 text-gray-500">{v?.summary}</p>
+                    <RichTextContent
+                      content={v?.summary}
+                      className="mt-4 text-gray-500 prose prose-sm max-w-none [&_ol]:pl-5 [&_p]:my-2 [&_ul]:pl-5"
+                    />
                   </article>
                 ))}
               </section>

--- a/Code/client/components/preview/ModernTemplate.tsx
+++ b/Code/client/components/preview/ModernTemplate.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { FaPhone, FaEnvelope, FaLink, FaMapMarkerAlt } from 'react-icons/fa';
+import RichTextContent from '@/components/common/RichTextContent';
 
 interface Props {
   data: any;
@@ -23,7 +24,10 @@ const ModernTemplate = ({ data: r, color, colorClasses, bgColorClasses }: Props)
           {r?.personal?.firstName} {r?.personal?.lastName}
         </h1>
         <h2 className="text-xl text-gray-600 mb-4 break-words">{r?.employments?.[0]?.title}</h2>
-        <p className="text-gray-600 mb-4 break-words whitespace-pre-wrap">{r?.personal?.summary}</p>
+        <RichTextContent
+          content={r?.personal?.summary}
+          className="mb-4 break-words text-gray-600 prose prose-sm max-w-none [&_ol]:pl-5 [&_p]:my-2 [&_ul]:pl-5"
+        />
         
         <div className="flex flex-wrap gap-4 text-gray-600">
           {r?.personal?.phone && (
@@ -124,8 +128,10 @@ const ModernTemplate = ({ data: r, color, colorClasses, bgColorClasses }: Props)
                         )}
                       </div>
                     </div>
-                    <div className="text-gray-600 prose prose-sm max-w-none [&_p]:my-0 [&_p]:break-words [&_span]:break-words" 
-                         dangerouslySetInnerHTML={{ __html: emp.summary }} />
+                    <RichTextContent
+                      content={emp.summary}
+                      className="text-gray-600 prose prose-sm max-w-none [&_ol]:pl-5 [&_p]:my-2 [&_p]:break-words [&_span]:break-words [&_ul]:pl-5"
+                    />
                   </div>
                 ))}
               </div>

--- a/Code/client/components/resume/EmploymentForm.tsx
+++ b/Code/client/components/resume/EmploymentForm.tsx
@@ -1,9 +1,10 @@
 import { nanoid } from "nanoid";
-import { UseFormRegister } from "react-hook-form";
+import { Control, UseFormRegister } from "react-hook-form";
 import ExperienceFormFields from "./ExperienceFormFields";
 
 interface EmploymentType {
   register: UseFormRegister<any>;
+  control: Control<any>;
   title: string;
   company: string;
   startDate: string;
@@ -27,6 +28,7 @@ export default function EmploymentForm(prop: EmploymentType) {
         </div>
         <ExperienceFormFields
           register={prop.register}
+          control={prop.control}
           index={prop.index}
           basePath="employments"
           title={prop.title}

--- a/Code/client/components/resume/ExperienceFormFields.tsx
+++ b/Code/client/components/resume/ExperienceFormFields.tsx
@@ -1,11 +1,12 @@
-import { UseFormRegister } from "react-hook-form";
+import { Control, Controller, UseFormRegister } from "react-hook-form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import RichTextEditor from "@/components/common/RichTextEditor";
 import { cn } from "@/lib/utils";
 
 type ExperienceFormFieldsProps = {
   register: UseFormRegister<any>;
+  control: Control<any>;
   index: number;
   basePath: "employments" | "internships";
   title: string;
@@ -25,6 +26,7 @@ const invalidFieldClassName = "border-destructive ring-destructive/20";
 
 export default function ExperienceFormFields({
   register,
+  control,
   index,
   basePath,
   title,
@@ -118,15 +120,17 @@ export default function ExperienceFormFields({
       <div className="grid grid-cols-1 gap-6">
         <div className="space-y-2">
           <Label className="text-muted-foreground">Summary*</Label>
-          <Textarea
-            className={cn("h-24", errors?.summary && invalidFieldClassName)}
-            aria-invalid={Boolean(errors?.summary)}
-            defaultValue={summary}
-            {...register(`${basePath}.${index}.summary`, {
-              required: true,
-              maxLength: 4000,
-              minLength: 50,
-            })}
+          <Controller
+            name={`${basePath}.${index}.summary`}
+            control={control}
+            render={({ field }) => (
+              <RichTextEditor
+                content={field.value ?? summary ?? ""}
+                onChange={field.onChange}
+                error={Boolean(errors?.summary)}
+                minHeightClassName="min-h-[8rem]"
+              />
+            )}
           />
         </div>
       </div>

--- a/Code/client/components/resume/Form.tsx
+++ b/Code/client/components/resume/Form.tsx
@@ -3,7 +3,7 @@
 import { useSafeUser } from "../../hooks/useSafeUser";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, Control, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { ResumeSchema } from "./ResumeSchema";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
@@ -20,6 +20,7 @@ import DraggableFormItem from "../common/DraggableFormItem";
 import Loader from "../Loader";
 import axios from "axios";
 import ScrollToTop from "../ScrollToTop";
+import RichTextEditor from "../common/RichTextEditor";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -30,8 +31,8 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { sanitizeResumeRichTextFields } from "@/utils/richText";
 
 const AddButton = ({ onClick, label }: { onClick: (e: any) => void; label: string }) => (
   <Button
@@ -129,7 +130,8 @@ const renderFormSection = (
   handlers: { handleAdd: any; handleDelete: any; handleReorder: any; handleMove: any },
   sectionErrors: any,
   addButtonLabel: string,
-  register: any
+  register: any,
+  control: Control<any>
 ) => (
   <div className="relative">
     <div className="space-y-4">
@@ -147,6 +149,7 @@ const renderFormSection = (
             <Component 
               {...item} 
               register={register} 
+              control={control}
               errors={sectionErrors && sectionErrors[index]} 
             />
           </DraggableFormItem>
@@ -167,6 +170,7 @@ export default function ResumeForm() {
 
   const {
     register,
+    control,
     handleSubmit,
     watch,
     setValue,
@@ -241,9 +245,11 @@ export default function ResumeForm() {
   const onSubmit: any = async (data: any) => {
     setSubmitError(null);
 
+    const normalizedResume = sanitizeResumeRichTextFields(data);
+
     const resumeData = {
       user: userId,
-      resume: data,
+      resume: normalizedResume,
     };
 
     setLocalResume(resumeData);
@@ -358,16 +364,21 @@ export default function ResumeForm() {
           <div className="grid grid-cols-1 gap-6">
             <div className="flex-1 space-y-2">
               <Label htmlFor="personal-summary" className="text-muted-foreground">Summary*</Label>
-              <Textarea
-                id="personal-summary"
-                rows={8}
-                className={cn(
-                  "h-60 md:h-40 lg:h-40",
-                  errors.personal?.summary && invalidFieldClassName
+              <Controller
+                name="personal.summary"
+                control={control}
+                render={({ field }) => (
+                  <RichTextEditor
+                    content={field.value ?? ""}
+                    onChange={field.onChange}
+                    error={Boolean(errors.personal?.summary)}
+                    minHeightClassName="min-h-[15rem] md:min-h-[10rem]"
+                  />
                 )}
-                aria-invalid={Boolean(errors.personal?.summary)}
-                {...register("personal.summary")}
               />
+              {errors?.personal?.summary && (
+                <p className="text-sm text-destructive">Please enter a stronger summary</p>
+              )}
             </div>
           </div>
         </FormSection>
@@ -382,7 +393,8 @@ export default function ResumeForm() {
             sections.educations,
             errors.educations,
             "Add Education",
-            register
+            register,
+            control
           )}
         </FormSection>
 
@@ -393,7 +405,8 @@ export default function ResumeForm() {
             sections.internships,
             errors.internships,
             "Add Internship",
-            register
+            register,
+            control
           )}
         </FormSection>
 
@@ -404,7 +417,8 @@ export default function ResumeForm() {
             sections.employments,
             errors.employments,
             "Add Employment",
-            register
+            register,
+            control
           )}
         </FormSection>
 
@@ -418,7 +432,8 @@ export default function ResumeForm() {
             sections.skills,
             errors.skills,
             "Add More Skill",
-            register
+            register,
+            control
           )}
         </FormSection>
 
@@ -429,7 +444,8 @@ export default function ResumeForm() {
             sections.languages,
             errors.languages,
             "Add More Language",
-            register
+            register,
+            control
           )}
         </FormSection>
 
@@ -443,7 +459,8 @@ export default function ResumeForm() {
             sections.links,
             errors.links,
             "Add More Links",
-            register
+            register,
+            control
           )}
         </FormSection>
 
@@ -454,7 +471,8 @@ export default function ResumeForm() {
             sections.courses,
             errors.courses,
             "Add Course",
-            register
+            register,
+            control
           )}
         </FormSection>
 
@@ -465,7 +483,8 @@ export default function ResumeForm() {
             sections.references,
             errors.references,
             "Add Reference",
-            register
+            register,
+            control
           )}
         </FormSection>
 

--- a/Code/client/components/resume/InternshipForm.tsx
+++ b/Code/client/components/resume/InternshipForm.tsx
@@ -1,9 +1,10 @@
 import { nanoid } from "nanoid";
-import { UseFormRegister } from "react-hook-form";
+import { Control, UseFormRegister } from "react-hook-form";
 import ExperienceFormFields from "./ExperienceFormFields";
 
 interface InternshipType {
   register: UseFormRegister<any>;
+  control: Control<any>;
   title: string;
   company: string;
   startDate: string;
@@ -27,6 +28,7 @@ export default function InternshipForm(prop: InternshipType) {
         </div>
         <ExperienceFormFields
           register={prop.register}
+          control={prop.control}
           index={prop.index}
           basePath="internships"
           title={prop.title}

--- a/Code/client/components/resume/ResumeSchema.tsx
+++ b/Code/client/components/resume/ResumeSchema.tsx
@@ -1,4 +1,13 @@
 import * as yup from "yup";
+import { getRichTextCharacterCount, isRichTextEffectivelyEmpty } from "@/utils/richText";
+
+const richTextSummary = (minimum: number, maximum: number) =>
+  yup
+    .string()
+    .test("required-visible-text", "required", (value) => !isRichTextEffectivelyEmpty(value))
+    .test("min-visible-text", `minimum-${minimum}`, (value) => getRichTextCharacterCount(value) >= minimum)
+    .test("max-visible-text", `maximum-${maximum}`, (value) => getRichTextCharacterCount(value) <= maximum)
+    .required();
 
 export const ResumeSchema = yup
   .object({
@@ -7,7 +16,7 @@ export const ResumeSchema = yup
       lastName: yup.string().min(2).required(),
       email: yup.string().email().required(),
       phone: yup.string().required(),
-      summary: yup.string().min(100).max(2000).required(),
+      summary: richTextSummary(100, 2000),
     }),
     educations: yup.array().of(
       yup
@@ -28,7 +37,7 @@ export const ResumeSchema = yup
         startDate: yup.string().required(),
         endDate: yup.string(),
         location: yup.string(),
-        summary: yup.string().min(100).max(4000).required(),
+        summary: richTextSummary(100, 4000),
       })
     ),
     employments: yup.array().of(
@@ -41,7 +50,7 @@ export const ResumeSchema = yup
           .when("isCurrent", { is: false, then: yup.string().required() }),
         location: yup.string(),
         isCurrent: yup.bool(),
-        summary: yup.string().min(100).max(4000).required(),
+        summary: richTextSummary(100, 4000),
       })
     ),
     skills: yup.array().of(

--- a/Code/client/package.json
+++ b/Code/client/package.json
@@ -60,6 +60,7 @@
 		"react-draggable": "^4.4.7",
 		"react-hook-form": "^7.54.2",
 		"react-icons": "^5.4.0",
+		"sanitize-html": "^2.17.3",
 		"tailwind-merge": "^3.5.0",
 		"tailwindcss": "^3.4.18",
 		"yup": "^0.32.11"
@@ -75,6 +76,7 @@
 		"@types/node": "^20.17.16",
 		"@types/react": "^19.2.0",
 		"@types/react-dom": "^19.2.0",
+		"@types/sanitize-html": "^2.16.1",
 		"baseline-browser-mapping": "^2.8.32",
 		"eslint": "^8.57.1",
 		"eslint-config-next": "^16.0.0",

--- a/Code/client/utils/richText.ts
+++ b/Code/client/utils/richText.ts
@@ -1,0 +1,92 @@
+import sanitizeHtml from "sanitize-html";
+
+const BLOCK_TAGS = /<(p|div|h[1-6]|li|ul|ol|blockquote)[^>]*>/gi;
+const TAGS = /<[^>]+>/g;
+const HTML_ENTITY_MAP: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+};
+
+export function hasRichTextMarkup(value: string | null | undefined) {
+  return /<[^>]+>/.test(value ?? "");
+}
+
+export function normalizeRichTextContent(value: string | null | undefined) {
+  const source = (value ?? "").trim();
+
+  if (!source) {
+    return "<p></p>";
+  }
+
+  if (hasRichTextMarkup(source)) {
+    return source;
+  }
+
+  const paragraphs = source
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+    .map((paragraph) => `<p>${paragraph.replace(/\n/g, "<br />")}</p>`);
+
+  return paragraphs.length > 0 ? paragraphs.join("") : "<p></p>";
+}
+
+export function sanitizeRichTextHtml(value: string | null | undefined) {
+  const normalizedContent = normalizeRichTextContent(value);
+
+  return sanitizeHtml(normalizedContent, {
+    allowedTags: ["p", "br", "strong", "b", "em", "i", "u", "ul", "ol", "li"],
+    allowedAttributes: {},
+    allowedSchemes: [],
+    disallowedTagsMode: "discard",
+  });
+}
+
+export function getPlainTextFromRichText(value: string | null | undefined) {
+  return sanitizeRichTextHtml(value)
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(BLOCK_TAGS, "\n")
+    .replace(TAGS, " ")
+    .replace(/&(nbsp|amp|lt|gt|quot|#39);/g, (match) => HTML_ENTITY_MAP[match] ?? " ")
+    .replace(/\s+\n/g, "\n")
+    .replace(/\n\s+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+}
+
+export function isRichTextEffectivelyEmpty(value: string | null | undefined) {
+  return getPlainTextFromRichText(value).length === 0;
+}
+
+export function getRichTextCharacterCount(value: string | null | undefined) {
+  return getPlainTextFromRichText(value).length;
+}
+
+export function sanitizeResumeRichTextFields<T extends Record<string, any>>(resume: T): T {
+  return {
+    ...resume,
+    personal: resume.personal
+      ? {
+          ...resume.personal,
+          summary: sanitizeRichTextHtml(resume.personal.summary),
+        }
+      : resume.personal,
+    employments: Array.isArray(resume.employments)
+      ? resume.employments.map((employment: Record<string, any>) => ({
+          ...employment,
+          summary: sanitizeRichTextHtml(employment.summary),
+        }))
+      : resume.employments,
+    internships: Array.isArray(resume.internships)
+      ? resume.internships.map((internship: Record<string, any>) => ({
+          ...internship,
+          summary: sanitizeRichTextHtml(internship.summary),
+        }))
+      : resume.internships,
+  };
+}

--- a/Code/client/yarn.lock
+++ b/Code/client/yarn.lock
@@ -2674,6 +2674,13 @@
   dependencies:
     csstype "^3.0.2"
 
+"@types/sanitize-html@^2.16.1":
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-2.16.1.tgz#27b9ac6cc29838f7a048bfec0113e8ad00918d0a"
+  integrity sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==
+  dependencies:
+    htmlparser2 "^10.1"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
@@ -3703,12 +3710,42 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
 domexception@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz"
   integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
   dependencies:
     webidl-conversions "^7.0.0"
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
@@ -3744,7 +3781,7 @@ emoji-regex@^9.2.2:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
-entities@^4.4.0:
+entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -3753,6 +3790,11 @@ entities@^6.0.0:
   version "6.0.1"
   resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz"
   integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 error-ex@^1.3.1:
   version "1.3.4"
@@ -4553,6 +4595,16 @@ html-escaper@^2.0.0:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+htmlparser2@^10.1, htmlparser2@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.1.0.tgz#fe3f2e12c73b6e462d4e10395db9c1119e4d6ae4"
+  integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    entities "^7.0.1"
+
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz"
@@ -4790,6 +4842,11 @@ is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -5948,6 +6005,11 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==
+
 parse5@^7.0.0, parse5@^7.1.1:
   version "7.3.0"
   resolved "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz"
@@ -6079,6 +6141,15 @@ postcss@8.4.31:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postcss@^8.3.11:
+  version "8.5.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.14.tgz#a66c2d7808fadf69ebb5b84a03f8bafd76c4919c"
+  integrity sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 postcss@^8.4.47, postcss@^8.5.1:
   version "8.5.6"
@@ -6539,6 +6610,18 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sanitize-html@^2.17.3:
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.17.3.tgz#b2f79f75afeda3a90e87d480052dfc1601b7aeee"
+  integrity sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==
+  dependencies:
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^10.1.0"
+    is-plain-object "^5.0.0"
+    parse-srcset "^1.0.2"
+    postcss "^8.3.11"
 
 saxes@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Summary
- replace plain text resume summary fields with a minimal rich text editor for profile, employment, and internship sections
- sanitize and normalize stored HTML, validate based on visible text length, and reuse a shared renderer in preview templates
- update resume form tests to cover the Controller-backed editor flow and sanitized submit payloads

## Validation
- node_modules/.bin/jest __tests__/components/resume/Form.test.tsx __tests__/components/resume/ResumeFieldComponents.test.tsx __tests__/app/resume/create/page.test.tsx __tests__/components/common/DraggableFormItem.test.tsx --runInBand --verbose
- browser check on /resume/create for editor rendering, typing, and toolbar toggle
- npx tsc --noEmit (still fails on pre-existing .next generated PrefetchForTypeCheckInternal errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rich-text editing capabilities for resume summaries (personal, employment, and internship sections) with an improved styled toolbar.
  * Rich-text content now properly displays in resume previews.

* **Tests**
  * Updated test suites to verify rich-text editor integration and content sanitization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aravin/Resume-Vita/pull/19)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->