### PR TITLE
Improve preview sharing and rich text safeguards

### DIFF
--- a/Code/client/__tests__/app/public/id-page.test.tsx
+++ b/Code/client/__tests__/app/public/id-page.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import Page from "@/app/public/[id]/page";
+import { useSignedUrl } from "../../../hooks/useSignedUrl";
+
+jest.mock("../../../hooks/useSignedUrl", () => ({
+  useSignedUrl: jest.fn(),
+}));
+
+describe("public resume page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders public resume actions when the signed PDF is available", async () => {
+    (useSignedUrl as jest.Mock).mockReturnValue({
+      getSignedUrl: jest.fn().mockResolvedValue("https://example.com/resume.pdf"),
+    });
+
+    render(<Page params={Promise.resolve({ id: "user-123" })} />);
+
+    expect(await screen.findByText("PDF preview is unavailable in this browser")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open/i })).toHaveAttribute(
+      "href",
+      "https://example.com/resume.pdf"
+    );
+  });
+
+  it("shows the missing resume state when no PDF exists", async () => {
+    (useSignedUrl as jest.Mock).mockReturnValue({
+      getSignedUrl: jest.fn().mockRejectedValue(new Error("PDF not found")),
+    });
+
+    render(<Page params={Promise.resolve({ id: "missing-user" })} />);
+
+    expect(await screen.findByText("Unable to load this resume")).toBeInTheDocument();
+    expect(screen.getByText(/resume not found or no longer available/i)).toBeInTheDocument();
+  });
+
+  it("downloads the public PDF through a temporary link", async () => {
+    const clickSpy = jest.fn();
+    const appendSpy = jest.spyOn(document.body, "appendChild");
+    const removeSpy = jest.spyOn(document.body, "removeChild");
+    const originalCreateElement = document.createElement.bind(document);
+    const createElementSpy = jest.spyOn(document, "createElement").mockImplementation(((tagName: string) => {
+      const element = originalCreateElement(tagName) as HTMLAnchorElement;
+
+      if (tagName === "a") {
+        element.click = clickSpy;
+      }
+
+      return element;
+    }) as typeof document.createElement);
+
+    (useSignedUrl as jest.Mock).mockReturnValue({
+      getSignedUrl: jest.fn().mockResolvedValue("https://example.com/resume.pdf"),
+    });
+
+    render(<Page params={Promise.resolve({ id: "user-123" })} />);
+
+  fireEvent.click(await screen.findByRole("button", { name: /download/i }));
+
+    await waitFor(() => {
+      expect(clickSpy).toHaveBeenCalled();
+      expect(appendSpy).toHaveBeenCalled();
+      expect(removeSpy).toHaveBeenCalled();
+    });
+
+    createElementSpy.mockRestore();
+    appendSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/Code/client/__tests__/app/resume/preview/page.test.tsx
+++ b/Code/client/__tests__/app/resume/preview/page.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import axios from "axios";
+import Page from "@/app/resume/preview/page";
+import { useSafeUser } from "../../../../hooks/useSafeUser";
+import useFetch from "../../../../hooks/useFetch";
+import { useDownloadPDF } from "../../../../hooks/useDownloadPDF";
+
+jest.mock("axios");
+
+jest.mock("../../../../hooks/useSafeUser", () => ({
+  useSafeUser: jest.fn(),
+}));
+
+jest.mock("../../../../hooks/useFetch", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("../../../../hooks/useDownloadPDF", () => ({
+  useDownloadPDF: jest.fn(),
+}));
+
+jest.mock("../../../../components/Breadcrumbs", () => ({
+  Breadcrumbs: ({ currentPage }: { currentPage: string }) => <div data-testid="breadcrumbs">{currentPage}</div>,
+}));
+
+jest.mock("../../../../components/preview/DefaultTemplate", () => ({
+  __esModule: true,
+  default: ({ color }: { color: string }) => <div data-testid="default-template">Default:{color}</div>,
+}));
+
+jest.mock("../../../../components/preview/ModernTemplate", () => ({
+  __esModule: true,
+  default: ({ color }: { color: string }) => <div data-testid="modern-template">Modern:{color}</div>,
+}));
+
+describe("resume preview page", () => {
+  const mockGenerateAndDownloadPDF = jest.fn();
+  const mockDownloadExistingPDF = jest.fn();
+  const mockResumeResponse = {
+    user: "user-123",
+    resume: {
+      personal: {
+        firstName: "Aravind",
+        lastName: "Appadurai",
+        summary: "<p>Senior engineer</p>",
+      },
+      employments: [{ title: "Lead Engineer" }],
+    },
+    color: "black",
+    template: "default",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSafeUser as jest.Mock).mockReturnValue({
+      user: { sub: "auth0|user-123" },
+      error: null,
+      isLoading: false,
+    });
+    (useFetch as jest.Mock).mockReturnValue({
+      data: mockResumeResponse,
+      fetching: false,
+      fetchError: null,
+    });
+    (useDownloadPDF as jest.Mock).mockReturnValue({
+      downloadExistingPDF: mockDownloadExistingPDF,
+      generateAndDownloadPDF: mockGenerateAndDownloadPDF,
+      isSignedUrlLoading: false,
+    });
+    (axios.post as jest.Mock).mockResolvedValue({ data: {} });
+  });
+
+  it("renders the saved preview configuration and default template", async () => {
+    render(<Page />);
+
+    expect(await screen.findByTestId("breadcrumbs")).toHaveTextContent("Resume Preview");
+    expect(screen.getByText("Preview Theme")).toBeInTheDocument();
+    expect(screen.getByTestId("default-template")).toHaveTextContent("Default:black");
+    expect(screen.getByText(/default template with the black accent/i)).toBeInTheDocument();
+  });
+
+  it("persists template and color changes without altering the resume payload", async () => {
+    render(<Page />);
+
+    await screen.findByTestId("default-template");
+
+    fireEvent.click(screen.getByRole("button", { name: /modern/i }));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/resume"),
+        expect.objectContaining({
+          user: "user-123",
+          resume: mockResumeResponse.resume,
+          color: "black",
+          template: "modern",
+        })
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /select blue color/i }));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/resume"),
+        expect.objectContaining({
+          user: "user-123",
+          resume: mockResumeResponse.resume,
+          color: "blue",
+          template: "modern",
+        })
+      );
+    });
+  });
+
+  it("falls back to the existing PDF only when generation fails on the backend", async () => {
+    mockGenerateAndDownloadPDF.mockRejectedValueOnce(new Error("PDF generation failed - backend error"));
+
+    render(<Page />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /download pdf/i }));
+
+    await waitFor(() => {
+      expect(mockDownloadExistingPDF).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user-123",
+          fileName: "ResumeVita.pdf",
+        })
+      );
+    });
+  });
+
+  it("does not fall back to an older PDF while a new one is still processing", async () => {
+    mockGenerateAndDownloadPDF.mockRejectedValueOnce(new Error("Generated PDF is still processing"));
+
+    render(<Page />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /download pdf/i }));
+
+    await waitFor(() => {
+      expect(mockGenerateAndDownloadPDF).toHaveBeenCalled();
+    });
+
+    expect(mockDownloadExistingPDF).not.toHaveBeenCalled();
+  });
+});

--- a/Code/client/__tests__/components/common/DraggableFormItem.test.tsx
+++ b/Code/client/__tests__/components/common/DraggableFormItem.test.tsx
@@ -43,6 +43,23 @@ describe("DraggableFormItem", () => {
     expect(defaultProps.onDelete).toHaveBeenCalledWith(1);
   });
 
+  it("closes the delete confirmation when cancel is clicked", () => {
+    render(
+      <DraggableFormItem {...defaultProps}>
+        <div>Item content</div>
+      </DraggableFormItem>
+    );
+
+    fireEvent.click(screen.getByTitle("Delete item"));
+
+    expect(screen.getByText("Delete?")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Delete?")).not.toBeInTheDocument();
+    expect(defaultProps.onDelete).not.toHaveBeenCalled();
+  });
+
   it("moves items through the control buttons", () => {
     render(
       <DraggableFormItem {...defaultProps}>

--- a/Code/client/__tests__/utils/richText.test.ts
+++ b/Code/client/__tests__/utils/richText.test.ts
@@ -1,0 +1,24 @@
+import { getPlainTextFromRichText, hasRichTextMarkup } from "@/utils/richText";
+
+describe("richText utilities", () => {
+  it("detects markup without regex backtracking", () => {
+    expect(hasRichTextMarkup("<p>Hello</p>")).toBe(true);
+    expect(hasRichTextMarkup("plain text only")).toBe(false);
+    expect(hasRichTextMarkup("2 < 3 and 4 > 1")).toBe(false);
+    expect(hasRichTextMarkup("unfinished <tag")).toBe(false);
+  });
+
+  it("extracts readable plain text from sanitized html", () => {
+    expect(
+      getPlainTextFromRichText(
+        "<p>Hello&nbsp;<strong>world</strong></p><ul><li>One</li><li>Two &amp; three</li></ul><p>Line<br />break</p>"
+      )
+    ).toBe("Hello world\nOne\nTwo & three\nLine\nbreak");
+  });
+
+  it("normalizes repeated whitespace and blank lines", () => {
+    expect(getPlainTextFromRichText("<p>  Hello   world  </p><p></p><p> Next line </p>")).toBe(
+      "Hello world\n\nNext line"
+    );
+  });
+});

--- a/Code/client/app/api/resume/[userId]/signed-url/route.ts
+++ b/Code/client/app/api/resume/[userId]/signed-url/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 // Configure AWS S3
@@ -11,6 +11,34 @@ const s3Client = new S3Client({
   region: process.env.AWS_S3_REGION || 'ap-south-2',
 });
 
+function isMissingObjectError(error: unknown) {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const maybeError = error as {
+    name?: string;
+    Code?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+
+  return (
+    maybeError.name === 'NotFound' ||
+    maybeError.name === 'NoSuchKey' ||
+    maybeError.Code === 'NoSuchKey' ||
+    maybeError.$metadata?.httpStatusCode === 404
+  );
+}
+
+async function ensureObjectExists(bucketName: string, fileKey: string) {
+  await s3Client.send(
+    new HeadObjectCommand({
+      Bucket: bucketName,
+      Key: fileKey,
+    })
+  );
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ userId: string }> }
@@ -19,6 +47,8 @@ export async function GET(
     const { userId } = await params;
     const bucketName = process.env.AWS_S3_BUCKET || 'resume-vita-bucket';
     const fileKey = `${userId}/${userId}.pdf`;
+
+    await ensureObjectExists(bucketName, fileKey);
     
     // Create the command
     const command = new GetObjectCommand({
@@ -38,7 +68,7 @@ export async function GET(
   } catch (error) {
     console.error('Error generating signed URL:', error);
     
-    if (error instanceof Error && 'name' in error && error.name === 'NoSuchKey') {
+    if (isMissingObjectError(error)) {
       return NextResponse.json({ error: 'PDF not found' }, { status: 404 });
     }
     
@@ -54,11 +84,16 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ userId: string }> }
 ) {
+  let fileType = 'pdf';
+
   try {
     const { userId } = await params;
-    const { fileType = 'pdf' } = await request.json();
+    const requestBody = await request.json().catch(() => ({}));
+    fileType = requestBody?.fileType || 'pdf';
     const bucketName = process.env.AWS_S3_BUCKET || 'resume-vita-bucket';
     const fileKey = `${userId}/${userId}.${fileType}`;
+
+    await ensureObjectExists(bucketName, fileKey);
     
     // Create the command
     const command = new GetObjectCommand({
@@ -77,6 +112,14 @@ export async function POST(
 
   } catch (error) {
     console.error('Error generating signed URL:', error);
+
+    if (isMissingObjectError(error)) {
+      return NextResponse.json(
+        { error: `${fileType.toUpperCase()} not found` },
+        { status: 404 }
+      );
+    }
+
     return NextResponse.json(
       { error: 'Failed to generate signed URL' }, 
       { status: 500 }

--- a/Code/client/app/public/[id]/page.tsx
+++ b/Code/client/app/public/[id]/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { FaDownload, FaExternalLinkAlt } from "react-icons/fa";
 import { useSignedUrl } from "@/hooks/useSignedUrl";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export default function Page({ params }: { params: Promise<{ id: string }> }) {
   const [id, setId] = useState<string | null>(null);
@@ -54,12 +57,31 @@ export default function Page({ params }: { params: Promise<{ id: string }> }) {
     loadSignedUrl();
   }, [id, getSignedUrl]);
 
+  const handleDownload = () => {
+    if (!signedUrl) return;
+
+    const link = document.createElement("a");
+    link.href = signedUrl;
+    link.download = `ResumeVita-${id || 'resume'}.pdf`;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.style.display = "none";
+
+    document.body.appendChild(link);
+    link.click();
+
+    setTimeout(() => {
+      document.body.removeChild(link);
+    }, 100);
+  };
+
   if (isLoading) {
     return (
-      <div className="fixed inset-0 flex items-center justify-center bg-white" style={{ zIndex: 9999 }}>
+      <div className="flex min-h-screen items-center justify-center bg-neutral-950 px-6 text-white">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading resume...</p>
+          <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-white/80"></div>
+          <h1 className="text-xl font-semibold">Loading public resume</h1>
+          <p className="mt-2 text-sm text-white/70">Fetching the latest shared PDF.</p>
         </div>
       </div>
     );
@@ -67,12 +89,11 @@ export default function Page({ params }: { params: Promise<{ id: string }> }) {
 
   if (error) {
     return (
-      <div className="fixed inset-0 flex items-center justify-center bg-white" style={{ zIndex: 9999 }}>
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold text-error mb-4">{error}</h1>
-          <p className="text-gray-600">
-            If you believe this is an error, please contact the resume owner.
-          </p>
+      <div className="flex min-h-screen items-center justify-center bg-neutral-950 px-6 text-white">
+        <div className="max-w-lg text-center">
+          <h1 className="text-2xl font-semibold text-white">Unable to load this resume</h1>
+          <p className="mt-3 text-sm text-white/70">{error}</p>
+          <p className="mt-2 text-sm text-white/55">Ask the resume owner to regenerate or reshare the PDF if this link should still work.</p>
         </div>
       </div>
     );
@@ -80,35 +101,44 @@ export default function Page({ params }: { params: Promise<{ id: string }> }) {
 
   if (!signedUrl) {
     return (
-      <div className="fixed inset-0 flex items-center justify-center bg-white" style={{ zIndex: 9999 }}>
+      <div className="flex min-h-screen items-center justify-center bg-neutral-950 px-6 text-white">
         <div className="text-center">
-          <h1 className="text-2xl font-semibold text-error mb-4">Unable to load resume</h1>
-          <p className="text-gray-600">
-            Please try again later.
-          </p>
+          <h1 className="text-2xl font-semibold">Resume unavailable</h1>
+          <p className="mt-2 text-sm text-white/70">Please try again later.</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="fixed inset-0 bg-white" style={{ zIndex: 9999 }}>
+    <div className="relative min-h-screen bg-neutral-950">
+      <div className="pointer-events-none fixed right-4 top-1/2 z-20 flex w-auto -translate-y-1/2 flex-col gap-3 sm:right-6">
+        <Button type="button" onClick={handleDownload} className="pointer-events-auto gap-2 shadow-lg">
+          <FaDownload className="text-sm" />
+          Download
+        </Button>
+        <a
+          href={signedUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(buttonVariants({ variant: "outline" }), "pointer-events-auto gap-2 border-white/20 bg-black/65 text-white shadow-lg backdrop-blur hover:bg-black/80 hover:text-white")}
+        >
+          <FaExternalLinkAlt className="text-xs" />
+          Open
+        </a>
+      </div>
+
       <object
-        className="w-full h-full"
+        className="h-screen w-full bg-white"
         data={signedUrl}
         type="application/pdf"
       >
-        <div className="flex items-center justify-center h-full">
-          <div className="text-center p-4">
-            <p className="mb-2">Unable to display the PDF in your browser.</p>
-            <a 
-              href={signedUrl}
-              className="text-primary hover:underline"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Click here to view or download the resume directly
-            </a>
+        <div className="flex min-h-screen items-center justify-center bg-neutral-950 p-6 text-white">
+          <div className="max-w-md text-center">
+            <h2 className="text-lg font-semibold">PDF preview is unavailable in this browser</h2>
+            <p className="mt-2 text-sm text-white/70">
+              Open the file in a new tab or download it directly to view the resume.
+            </p>
           </div>
         </div>
       </object>

--- a/Code/client/app/resume/preview/page.tsx
+++ b/Code/client/app/resume/preview/page.tsx
@@ -9,13 +9,15 @@ import Link from "next/link";
 import { FaFilePdf, FaEdit } from "react-icons/fa";
 import axios from "axios";
 import useFetch from "../../../hooks/useFetch";
-import { useSignedUrl } from "../../../hooks/useSignedUrl";
 import { useDownloadPDF } from "../../../hooks/useDownloadPDF";
 import { useEffect, useState, useMemo, memo, useCallback } from "react";
 import Loader from "../../../components/Loader";
 import { Breadcrumbs } from "../../../components/Breadcrumbs";
 import DefaultTemplate from "@/components/preview/DefaultTemplate";
 import ModernTemplate from "@/components/preview/ModernTemplate";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 const colorClasses = {
   black: "text-black",
@@ -36,6 +38,29 @@ const bgColorClasses = {
   yellow: "bg-yellow-500",
   pink: "bg-pink-500"
 };
+
+const templateOptions = [
+  {
+    value: "default",
+    name: "Default",
+    description: "Balanced two-column layout for classic resumes.",
+  },
+  {
+    value: "modern",
+    name: "Modern",
+    description: "More visual emphasis for current experience and skills.",
+  },
+] as const;
+
+const colorOptions = [
+  { name: "Black", value: "black", bg: "bg-black" },
+  { name: "Gray", value: "gray", bg: "bg-gray-500" },
+  { name: "Blue", value: "blue", bg: "bg-blue-500" },
+  { name: "Red", value: "red", bg: "bg-red-500" },
+  { name: "Green", value: "green", bg: "bg-green-500" },
+  { name: "Yellow", value: "yellow", bg: "bg-yellow-500" },
+  { name: "Pink", value: "pink", bg: "bg-pink-500" },
+] as const;
 
 const SectionTitle = memo(({ children, color }: { children: React.ReactNode; color: keyof typeof colorClasses }) => (
   <>
@@ -71,6 +96,8 @@ export default function Page() {
   const [color, setColor] = useState<keyof typeof colorClasses>("black");
   const [template, setTemplate] = useState<'default' | 'modern'>('default');
   const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [themeSaveError, setThemeSaveError] = useState<string | null>(null);
+  const [isSavingTheme, setIsSavingTheme] = useState(false);
 
   // Set document title
   useEffect(() => {
@@ -78,7 +105,6 @@ export default function Page() {
   }, []);
 
   const { user, error: authError, isLoading: authLoading } = useSafeUser();
-  const { getSignedUrl, isLoading: isSignedUrlLoading, error: signedUrlError } = useSignedUrl();
   const { downloadExistingPDF, generateAndDownloadPDF, isSignedUrlLoading: isDownloadLoading } = useDownloadPDF();
   
   const userId = useMemo(() => {
@@ -94,7 +120,7 @@ export default function Page() {
   );
 
   const storedResume = data;
-  const r = storedResume?.user === userId ? storedResume?.resume : {};
+  const r = useMemo(() => (storedResume?.user === userId ? storedResume?.resume : {}), [storedResume, userId]);
 
   useEffect(() => {
     if (data?.color) {
@@ -112,6 +138,33 @@ export default function Page() {
       setLoader(false);
     }
   }, [fetching]);
+
+  const persistPreviewTheme = useCallback(
+    async (nextColor: keyof typeof colorClasses, nextTemplate: 'default' | 'modern') => {
+      if (!userId) return;
+
+      setThemeSaveError(null);
+      setIsSavingTheme(true);
+
+      try {
+        await axios.post(
+          process.env.NEXT_PUBLIC_BACKEND_API_ENDPOINT + "/resume",
+          {
+            user: userId,
+            resume: r,
+            color: nextColor,
+            template: nextTemplate,
+          }
+        );
+      } catch (error) {
+        console.error("Failed to save preview theme:", error);
+        setThemeSaveError("Theme changes were applied locally but could not be saved.");
+      } finally {
+        setIsSavingTheme(false);
+      }
+    },
+    [r, userId]
+  );
 
   const handleDownload = useCallback(async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -138,6 +191,10 @@ export default function Page() {
         fileName: "ResumeVita.pdf"
       });
     } catch (error) {
+      if (!(error instanceof Error) || error.message !== 'PDF generation failed - backend error') {
+        return;
+      }
+
       console.error('PDF generation failed, falling back to existing PDF:', error);
       
       // Clear any error messages from failed generation
@@ -156,11 +213,13 @@ export default function Page() {
 
   const handleColorChange = useCallback((newColor: keyof typeof colorClasses) => {
     setColor(newColor);
-  }, []);
+    void persistPreviewTheme(newColor, template);
+  }, [persistPreviewTheme, template]);
 
   const handleTemplateChange = useCallback((newTemplate: 'default' | 'modern') => {
     setTemplate(newTemplate);
-  }, []);
+    void persistPreviewTheme(color, newTemplate);
+  }, [color, persistPreviewTheme]);
 
   if (authLoading || fetching)
     return (
@@ -204,87 +263,127 @@ export default function Page() {
     <>
       <Breadcrumbs currentPage="Resume Preview" />
 
-      <div className="flex flex-col md:flex-row items-stretch gap-6 p-4 bg-gray-50 rounded-lg shadow-sm">
-        
-
-        {/* Template Picker Section */}
-        <div className="flex flex-wrap justify-center gap-3">
-          {[
-            { name: "Default Template", value: "default" },
-            { name: "Modern Template", value: "modern" }
-          ].map((templateOption) => (
-            <button
-              key={templateOption.value}
-              className={`px-4 py-2 rounded transition-colors ${
-                template === templateOption.value 
-                  ? bgColorClasses[color] + ' text-white' 
-                  : 'border border-gray-300 hover:bg-gray-50'
-              }`}
-              onClick={() => handleTemplateChange(templateOption.value as 'default' | 'modern')}
-            >
-              {templateOption.name}
-            </button>
-          ))}
-        </div>
-
-        {/* Color Picker Section */}
-        <div className="flex flex-col sm:flex-row items-center gap-4">
-          <h3 className="text-sm font-medium text-gray-700 whitespace-nowrap">Color:</h3>
-          <div className="grid grid-cols-4 sm:grid-cols-7 gap-3">
-            {[
-              { name: "Black", value: "black", bg: "bg-black" },
-              { name: "Gray", value: "gray", bg: "bg-gray-500" },
-              { name: "Blue", value: "blue", bg: "bg-blue-500" },
-              { name: "Red", value: "red", bg: "bg-red-500" },
-              { name: "Green", value: "green", bg: "bg-green-500" },
-              { name: "Yellow", value: "yellow", bg: "bg-yellow-500" },
-              { name: "Pink", value: "pink", bg: "bg-pink-500" }
-            ].map((colorOption) => (
-              <div key={colorOption.value} className="group relative">
-                <button
-                  onClick={() => handleColorChange(colorOption.value as keyof typeof colorClasses)}
-                  className="w-8 h-8 rounded-full flex items-center justify-center hover:scale-110 transition-transform"
-                  aria-label={`Select ${colorOption.name} color`}
-                >
-                  <div className={`w-6 h-6 ${colorOption.bg} rounded-full ring-2 ring-offset-2 ${
-                    color === colorOption.value ? "ring-gray-500" : "ring-transparent"
-                  }`} />
-                </button>
-                <div className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-gray-800 text-white text-xs rounded 
-                             opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap">
-                  {colorOption.name}
-                </div>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
+        <Card className="border-border/70 bg-card/95 shadow-sm xl:sticky xl:top-24 xl:h-fit">
+          <CardHeader>
+            <CardTitle>Preview Theme</CardTitle>
+            <CardDescription>
+              Switch templates, adjust the accent color, and download the current preview.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-3">
+              <div>
+                <p className="text-sm font-medium text-foreground">Template</p>
+                <p className="text-sm text-muted-foreground">Choose the layout that matches your target role.</p>
               </div>
-            ))}
-          </div>
-        </div>
+              <div className="grid gap-3">
+                {templateOptions.map((templateOption) => {
+                  const isActive = template === templateOption.value;
 
-        {/* Action Buttons */}
-        <div className="flex flex-wrap justify-center gap-3 ml-auto">
-          <button
-            className="btn btn-sm btn-outline btn-accent gap-2 min-w-[40px]"
-            onClick={handleDownload}
-            title="Download PDF"
-            disabled={loading || isSignedUrlLoading}
-          >
-            <FaFilePdf className="text-lg" />
-            <span className="hidden sm:inline">
-              {loading || isSignedUrlLoading ? 'Generating...' : 'Download PDF'}
-            </span>
-          </button>
-          <Link href="/resume/create" passHref>
-            <button 
-              className="btn btn-sm btn-outline btn-primary gap-2 min-w-[40px]"
-              title="Edit Resume"
-            >
-              <FaEdit className="text-lg" />
-              <span className="hidden sm:inline">Edit Resume</span>
-            </button>
-          </Link>
-        </div>
-      </div>
+                  return (
+                    <button
+                      key={templateOption.value}
+                      type="button"
+                      onClick={() => handleTemplateChange(templateOption.value)}
+                      className={cn(
+                        "rounded-xl border px-4 py-3 text-left transition-colors",
+                        isActive
+                          ? `${bgColorClasses[color]} text-white border-transparent shadow-sm`
+                          : "border-border/70 bg-background hover:border-primary/40 hover:bg-muted/40"
+                      )}
+                      aria-pressed={isActive}
+                    >
+                      <div className="font-medium">{templateOption.name}</div>
+                      <div className={cn("mt-1 text-sm", isActive ? "text-white/85" : "text-muted-foreground")}>{templateOption.description}</div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
 
-      <div id="preview" className="flex justify-center items-center w-full overflow-auto">
+            <div className="space-y-3">
+              <div>
+                <p className="text-sm font-medium text-foreground">Accent Color</p>
+                <p className="text-sm text-muted-foreground">Apply a consistent accent across headings and highlights.</p>
+              </div>
+              <div className="grid grid-cols-4 gap-3 sm:grid-cols-7 xl:grid-cols-4">
+                {colorOptions.map((colorOption) => {
+                  const isActive = color === colorOption.value;
+
+                  return (
+                    <button
+                      key={colorOption.value}
+                      type="button"
+                      onClick={() => handleColorChange(colorOption.value)}
+                      className="group flex flex-col items-center gap-2"
+                      aria-label={`Select ${colorOption.name} color`}
+                      aria-pressed={isActive}
+                    >
+                      <span
+                        className={cn(
+                          "flex h-11 w-11 items-center justify-center rounded-full border border-border/60 bg-background transition-transform group-hover:scale-105",
+                          isActive && "border-primary shadow-sm"
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            "h-7 w-7 rounded-full ring-2 ring-offset-2 ring-offset-background",
+                            colorOption.bg,
+                            isActive ? "ring-primary" : "ring-transparent"
+                          )}
+                        />
+                      </span>
+                      <span className="text-xs font-medium text-muted-foreground">{colorOption.name}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-border/70 bg-muted/30 p-4 text-sm">
+              <p className="font-medium text-foreground">Current selection</p>
+              <p className="mt-1 text-muted-foreground">
+                {templateOptions.find((option) => option.value === template)?.name} template with the {colorOptions.find((option) => option.value === color)?.name?.toLowerCase()} accent.
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {isSavingTheme
+                  ? "Saving theme preferences..."
+                  : themeSaveError
+                    ? themeSaveError
+                    : "Theme changes are saved automatically for future visits."}
+              </p>
+            </div>
+
+            {downloadError && (
+              <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                {downloadError}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-3 sm:flex-row xl:flex-col">
+              <Button
+                type="button"
+                onClick={handleDownload}
+                className="w-full gap-2"
+                disabled={loading || isDownloadLoading}
+              >
+                <FaFilePdf className="text-base" />
+                {loading || isDownloadLoading ? "Generating PDF..." : "Download PDF"}
+              </Button>
+              <Link
+                href="/resume/create"
+                className={cn(buttonVariants({ variant: "outline" }), "w-full gap-2")}
+              >
+                <FaEdit className="text-base" />
+                Edit Resume
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="rounded-3xl border border-border/70 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.08),_transparent_35%),linear-gradient(to_bottom,_rgba(255,255,255,0.98),_rgba(248,250,252,0.92))] p-3 shadow-sm sm:p-6">
+          <div id="preview" className="flex w-full items-start justify-center overflow-auto rounded-2xl bg-white/70 p-2 sm:p-4">
         {template === 'default' ? (
           <DefaultTemplate 
             data={r} 
@@ -300,6 +399,8 @@ export default function Page() {
             bgColorClasses={bgColorClasses} 
           />
         )}
+          </div>
+        </div>
       </div>
     </>
   );

--- a/Code/client/components/Layout.tsx
+++ b/Code/client/components/Layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { usePathname } from "next/navigation";
 import Footer from "./Footer";
 
 // Dynamically import Navbar to prevent SSR execution
@@ -9,6 +10,13 @@ const Navbar = dynamic(() => import("./Navbar"), {
 });
 
 export default function Layout({ children }: any) {
+  const pathname = usePathname();
+  const isPublicResumeRoute = pathname?.startsWith("/public/");
+
+  if (isPublicResumeRoute) {
+    return children;
+  }
+
   return (
     <>
       <Navbar />

--- a/Code/client/components/common/DraggableFormItem.tsx
+++ b/Code/client/components/common/DraggableFormItem.tsx
@@ -80,7 +80,7 @@ const DraggableFormItem: React.FC<DraggableFormItemProps> = ({
         `}
       >
         {/* Delete button and confirmation */}
-        <div className="absolute right-2 top-2 flex items-center gap-2">
+        <div className="absolute right-2 top-2 z-30 flex items-center gap-2">
           {showDeleteConfirm ? (
             <div className="flex items-center gap-2 rounded-xl border border-border/70 bg-background px-2 py-1 shadow-md">
               <span className="text-sm text-muted-foreground">Delete?</span>
@@ -96,7 +96,7 @@ const DraggableFormItem: React.FC<DraggableFormItemProps> = ({
                 onClick={cancelDelete}
                 className="rounded-md bg-muted px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted/80"
               >
-                No
+                Cancel
               </button>
             </div>
           ) : (
@@ -112,7 +112,11 @@ const DraggableFormItem: React.FC<DraggableFormItemProps> = ({
         </div>
 
         {/* Movement controls */}
-        <div className="absolute left-4 top-4 right-14 flex flex-wrap items-center gap-1.5">
+        <div
+          className={`absolute left-4 top-4 z-10 flex flex-wrap items-center gap-1.5 ${
+            showDeleteConfirm ? 'right-44 md:right-48' : 'right-14'
+          }`}
+        >
           <button 
             type="button"
             title="Drag to reorder"

--- a/Code/client/hooks/useDownloadPDF.ts
+++ b/Code/client/hooks/useDownloadPDF.ts
@@ -22,6 +22,45 @@ interface GeneratePDFOptions {
 export const useDownloadPDF = () => {
   const { getSignedUrl, isLoading: isSignedUrlLoading } = useSignedUrl();
 
+  const triggerBrowserDownload = (signedUrl: string, fileName: string) => {
+    const link = document.createElement("a");
+    link.href = signedUrl;
+    link.download = fileName;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.style.display = "none";
+
+    document.body.appendChild(link);
+    link.click();
+
+    setTimeout(() => {
+      document.body.removeChild(link);
+    }, 100);
+  };
+
+  const waitForSignedAsset = async (
+    userId: string,
+    fileType: string,
+    attempts = 10,
+    delayMs = 500
+  ) => {
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        return await getSignedUrl(userId, fileType);
+      } catch (error) {
+        const isMissingAsset = error instanceof Error && error.message.toLowerCase().includes("not found");
+
+        if (!isMissingAsset || attempt === attempts - 1) {
+          throw error;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+
+    throw new Error("Generated PDF is still processing");
+  };
+
   const downloadExistingPDF = async (options: DownloadOptions) => {
     const { userId, setDownloadError, setLoading, fileName = "ResumeVita.pdf" } = options;
     
@@ -31,24 +70,11 @@ export const useDownloadPDF = () => {
     try {
       // Get signed URL for download
       const signedUrl = await getSignedUrl(userId, 'pdf');
-      
-      // Use direct download to avoid CORS issues
-      const link = document.createElement("a");
-      link.href = signedUrl;
-      link.download = fileName;
-      link.target = "_blank";
-      link.style.display = 'none';
-      
-      document.body.appendChild(link);
-      link.click();
+
+      triggerBrowserDownload(signedUrl, fileName);
       
       // Track PDF download
       trackPDFDownload('dashboard');
-      
-      setTimeout(() => {
-        document.body.removeChild(link);
-      }, 100);
-      
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
       setDownloadError(errorMessage);
@@ -75,29 +101,12 @@ export const useDownloadPDF = () => {
       // Generate PDF on backend
       await axios.post(`${process.env.NEXT_PUBLIC_BACKEND_API_ENDPOINT}/pdf`, body);
 
-      // Wait a moment for PDF processing to complete
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      const signedUrl = await waitForSignedAsset(userId, 'pdf');
 
-      // Get signed URL for download
-      const signedUrl = await getSignedUrl(userId, 'pdf');
-      
-      // Use direct download to avoid CORS issues
-      const link = document.createElement("a");
-      link.href = signedUrl;
-      link.download = fileName;
-      link.target = "_blank";
-      link.style.display = 'none';
-      
-      document.body.appendChild(link);
-      link.click();
+      triggerBrowserDownload(signedUrl, fileName);
       
       // Track PDF download
       trackPDFDownload('preview');
-      
-      setTimeout(() => {
-        document.body.removeChild(link);
-      }, 100);
-      
     } catch (error) {
       console.error('PDF generation error:', error);
       
@@ -111,6 +120,10 @@ export const useDownloadPDF = () => {
         } else {
           setDownloadError(`Server error: ${error.response?.status || 'Unknown'}`);
         }
+      } else if (error instanceof Error && error.message.toLowerCase().includes('not found')) {
+        setDownloadError('The updated PDF is still being prepared. Please try again in a moment.');
+      } else if (error instanceof Error && error.message === 'Generated PDF is still processing') {
+        setDownloadError('The updated PDF is still being prepared. Please try again in a moment.');
       } else {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
         setDownloadError(errorMessage);

--- a/Code/client/utils/richText.ts
+++ b/Code/client/utils/richText.ts
@@ -1,7 +1,6 @@
 import sanitizeHtml from "sanitize-html";
 
-const BLOCK_TAGS = /<(p|div|h[1-6]|li|ul|ol|blockquote)[^>]*>/gi;
-const TAGS = /<[^>]+>/g;
+const BLOCK_LEVEL_TAGS = new Set(["p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li", "blockquote"]);
 const HTML_ENTITY_MAP: Record<string, string> = {
   "&nbsp;": " ",
   "&amp;": "&",
@@ -11,8 +10,174 @@ const HTML_ENTITY_MAP: Record<string, string> = {
   "&#39;": "'",
 };
 
+function isWhitespaceCharacter(character: string) {
+  return (
+    character === " " ||
+    character === "\n" ||
+    character === "\r" ||
+    character === "\t" ||
+    character === "\f" ||
+    character === "\v" ||
+    character === "\u00A0"
+  );
+}
+
+function extractTagName(tagContent: string) {
+  const trimmedTagContent = tagContent.trim().replace(/^\//, "");
+  const firstCharacter = trimmedTagContent[0];
+
+  if (!firstCharacter || !((firstCharacter >= "a" && firstCharacter <= "z") || (firstCharacter >= "A" && firstCharacter <= "Z"))) {
+    return "";
+  }
+
+  let index = 0;
+
+  while (index < trimmedTagContent.length) {
+    const character = trimmedTagContent[index];
+
+    if (
+      (character >= "a" && character <= "z") ||
+      (character >= "A" && character <= "Z") ||
+      (character >= "0" && character <= "9")
+    ) {
+      index += 1;
+      continue;
+    }
+
+    break;
+  }
+
+  return trimmedTagContent.slice(0, index).toLowerCase();
+}
+
+function decodeHtmlEntity(value: string, startIndex: number) {
+  for (const [entity, replacement] of Object.entries(HTML_ENTITY_MAP)) {
+    if (value.startsWith(entity, startIndex)) {
+      return {
+        replacement,
+        nextIndex: startIndex + entity.length,
+      };
+    }
+  }
+
+  return null;
+}
+
+function collapseInlineWhitespace(value: string) {
+  let result = "";
+  let pendingWhitespace = false;
+
+  for (const character of value) {
+    if (character === "\r") {
+      continue;
+    }
+
+    if (isWhitespaceCharacter(character)) {
+      pendingWhitespace = result.length > 0;
+      continue;
+    }
+
+    if (pendingWhitespace) {
+      result += " ";
+      pendingWhitespace = false;
+    }
+
+    result += character;
+  }
+
+  return result;
+}
+
+function normalizePlainText(value: string) {
+  const normalizedValue = value.replaceAll("\r", "");
+  const lines = normalizedValue.split("\n");
+  const normalizedLines: string[] = [];
+  let previousLineWasBlank = true;
+
+  for (const line of lines) {
+    const collapsedLine = collapseInlineWhitespace(line);
+
+    if (!collapsedLine) {
+      if (!previousLineWasBlank && normalizedLines.length > 0) {
+        normalizedLines.push("");
+      }
+      previousLineWasBlank = true;
+      continue;
+    }
+
+    normalizedLines.push(collapsedLine);
+    previousLineWasBlank = false;
+  }
+
+  return normalizedLines.join("\n").trim();
+}
+
+function extractPlainTextFromSanitizedHtml(value: string) {
+  let result = "";
+  let index = 0;
+
+  while (index < value.length) {
+    const character = value[index];
+
+    if (character === "<") {
+      const closingIndex = value.indexOf(">", index + 1);
+
+      if (closingIndex === -1) {
+        result += "<";
+        index += 1;
+        continue;
+      }
+
+      const tagContent = value.slice(index + 1, closingIndex);
+      const tagName = extractTagName(tagContent);
+      const isClosingTag = tagContent.trim().startsWith("/");
+
+      if (tagName === "br") {
+        result += "\n";
+      } else if (!isClosingTag && BLOCK_LEVEL_TAGS.has(tagName)) {
+        result += "\n";
+      }
+
+      index = closingIndex + 1;
+      continue;
+    }
+
+    if (character === "&") {
+      const decodedEntity = decodeHtmlEntity(value, index);
+
+      if (decodedEntity) {
+        result += decodedEntity.replacement;
+        index = decodedEntity.nextIndex;
+        continue;
+      }
+    }
+
+    result += character;
+    index += 1;
+  }
+
+  return normalizePlainText(result);
+}
+
 export function hasRichTextMarkup(value: string | null | undefined) {
-  return /<[^>]+>/.test(value ?? "");
+  const source = value ?? "";
+  let index = source.indexOf("<");
+
+  while (index !== -1) {
+    const closingIndex = source.indexOf(">", index + 1);
+
+    if (closingIndex === -1) {
+      return false;
+    }
+
+    if (extractTagName(source.slice(index + 1, closingIndex))) {
+      return true;
+    }
+
+    index = source.indexOf("<", index + 1);
+  }
+
+  return false;
 }
 
 export function normalizeRichTextContent(value: string | null | undefined) {
@@ -47,16 +212,7 @@ export function sanitizeRichTextHtml(value: string | null | undefined) {
 }
 
 export function getPlainTextFromRichText(value: string | null | undefined) {
-  return sanitizeRichTextHtml(value)
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(BLOCK_TAGS, "\n")
-    .replace(TAGS, " ")
-    .replace(/&(nbsp|amp|lt|gt|quot|#39);/g, (match) => HTML_ENTITY_MAP[match] ?? " ")
-    .replace(/\s+\n/g, "\n")
-    .replace(/\n\s+/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .replace(/[ \t]{2,}/g, " ")
-    .trim();
+  return extractPlainTextFromSanitizedHtml(sanitizeRichTextHtml(value));
 }
 
 export function isRichTextEffectivelyEmpty(value: string | null | undefined) {


### PR DESCRIPTION
## Summary
- persist preview theme changes and harden PDF generation/download fallbacks
- simplify the public resume viewer and remove full-site chrome for shared resumes
- harden rich text parsing against regex DoS risks and fix delete cancel behavior

## Testing
- node_modules/.bin/jest __tests__/app/public/id-page.test.tsx __tests__/app/resume/preview/page.test.tsx __tests__/components/common/DraggableFormItem.test.tsx __tests__/utils/richText.test.ts --runInBand --verbose